### PR TITLE
Fixed group description bug

### DIFF
--- a/src/GoatTrip.RestApi/GoatTrip.RestApi.csproj
+++ b/src/GoatTrip.RestApi/GoatTrip.RestApi.csproj
@@ -86,6 +86,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />

--- a/src/GoatTrip.RestApi/Models/LocationModel.cs
+++ b/src/GoatTrip.RestApi/Models/LocationModel.cs
@@ -1,6 +1,8 @@
 ﻿using GoatTrip.DAL.DTOs;
 
 namespace GoatTrip.RestApi.Models {
+    using System.Runtime.Serialization;
+
     public class LocationModel {
 
         public LocationModel() { }
@@ -34,6 +36,7 @@ namespace GoatTrip.RestApi.Models {
         public CoordinateModel Coordinate { get; set; }
         public string HouseNumber { get; set; }
 
+        [IgnoreDataMember]
         public string GroupDescription {
             get {
                 var result = "";

--- a/tests/GoatTrip.RestApi.IntegrationTests/Controllers/LocationControllerTests.cs
+++ b/tests/GoatTrip.RestApi.IntegrationTests/Controllers/LocationControllerTests.cs
@@ -1,0 +1,52 @@
+﻿
+namespace GoatTrip.RestApi.IntegrationTests.Controllers {
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Web.Http;
+    using Moq;
+    using RestApi.Controllers;
+    using RestApi.Models;
+    using Services;
+    using Xunit;
+
+    public class LocationControllerTests {
+
+        [Fact]
+        [Trait("Category", "integration")]
+        public void Get_Never_SerialisesGroupDescription()
+        {
+            var mockValidator = new Mock<ILocationQueryValidator>();
+            mockValidator.Setup(v => v.IsValid(It.IsAny<string>())).Returns(true);
+
+            var fakeLocation = new LocationModel {
+                Postcode = "test"
+            };
+
+            var mockService = new Mock<ILocationService>();
+            mockService.Setup(s => s.Get(It.IsAny<string>())).Returns(new List<LocationGroupModel> {
+                new LocationGroupModel {
+                    Description = fakeLocation.GroupDescription,
+                    Locations = new List<LocationModel> {
+                        fakeLocation
+                    }
+                }
+            });
+
+            var sut = new LocationController(mockValidator.Object, mockService.Object) {
+                Configuration = new HttpConfiguration(),
+                Request = new HttpRequestMessage()
+            };
+
+            var result = sut.Get("test");
+
+            var response = result.ExecuteAsync(new CancellationToken(false));
+            var content = response.Result.Content.ReadAsStringAsync().Result;
+
+            dynamic json = Newtonsoft.Json.JsonConvert.DeserializeObject(content);
+            Assert.NotNull(json[0]["Description"]);
+            Assert.Null(json[0]["Locations"][0]["GroupDescription"]);
+        }
+
+    }
+}

--- a/tests/GoatTrip.RestApi.IntegrationTests/GoatTrip.RestApi.IntegrationTests.csproj
+++ b/tests/GoatTrip.RestApi.IntegrationTests/GoatTrip.RestApi.IntegrationTests.csproj
@@ -64,6 +64,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Controllers\LocationControllerTests.cs" />
     <Compile Include="Models\LocationModelTests.cs" />
     <Compile Include="RouteInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
GroupDescription was being displayed at the LocationModel level which confused the response. Now it is removed and only appears at the Group level as 'Description'.